### PR TITLE
More consistent thread stopping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ message_loop = [
     "winapi/hidusage"
 ]
 
+[dependencies]
+stoppable_thread = "*"
+
 [dependencies.winapi]
 version = "0.3"
 default-features = false


### PR DESCRIPTION
Why have one function `message_loop.stop()` that only works some of the time when you can use a `stoppable_thread` in the receiver and call `reciever.stop()` which works all the time. This is not meant to be complete since I did not take into account the `STATE` variable since I have no clue how it works. But I think it's a good start. Before this fork the only way to break out of a `message_loop` was to run `break` somewhere inside the `next_event` match statement. This is not always convienient though, so this is a way to stop the message_loop reliably from anywhere in the code.