### PR TITLE
Issue 10: support for safe conversion of `u8` into `Vk`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winput"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Gymore <gymore.contact@gmail.com>"]
 edition = "2018"
 description = "A high-level interface to Windows' input system."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ message_loop = [
     "winapi/hidusage"
 ]
 
+[dependencies.lazy_static]
+version = "1.4.0"
+
 [dependencies.winapi]
 version = "0.3"
 default-features = false
@@ -37,6 +40,9 @@ features = ["winuser", "errhandlingapi", "winbase"]
 [dependencies.serde]
 version = "1"
 optional = true
+
+[dependencies.strum]
+version = "0.26"
 features = [ "derive" ]
 
 [badges.maintenance]

--- a/src/input.rs
+++ b/src/input.rs
@@ -79,6 +79,10 @@ impl Input {
                 Action::Release => winuser::KEYEVENTF_KEYUP,
                 Action::Press => 0,
             };
+            // ensure that extended keys have the extended flag set
+            if vk.is_extended() {
+                ki.dwFlags |= winuser::KEYEVENTF_EXTENDEDKEY;
+            }
             ki.time = 0; // let the system provide a time stamp
 
             Self(input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate lazy_static;
+
 mod error;
 pub use error::WindowsError;
 

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -767,8 +767,13 @@ impl Vk {
             // ... NUM LOCK key; the BREAK (CTRL+PAUSE) key; the PRINT SCRN key;
             Vk::Numlock | Vk::Pause | Vk::PrintScreen |
             // ... the divide (/) and ENTER keys in the numeric keypad.
-            Vk::Divide
-            
+            Vk::Divide |
+            // Extended keys not explicitly listed in Microsoft's documentation
+            Vk::LeftWin |
+            Vk::BrowserSearch |
+            Vk::VolumeDown | Vk::VolumeUp | Vk::NextTrack | Vk::PrevTrack |
+            Vk::MediaStop | Vk::MediaPlayPause | Vk:: SelectMedia |
+            Vk::StartMail | Vk::Apps | Vk::StartApp1 | Vk::StartApp2
             => true,
             _ => false,
         }

--- a/src/vk.rs
+++ b/src/vk.rs
@@ -738,4 +738,39 @@ impl Vk {
         let state = unsafe { GetKeyState(self.into()) } as u16;
         state & MASK == MASK
     }
+
+    /// Is the key extended.
+    /// 
+    /// Windows considers some keys as [extended][1]. Failure to mark them
+    /// as such when sending them will prevent proper processing (e.g., 
+    /// Shift + Arrow might [not extend the selection][2]).
+    /// 
+    /// ## Example
+    /// ```
+    /// use winput::Vk;
+    ///
+    /// assert_eq!(Vk::Z.is_extended(), false);
+    /// assert_eq!(Vk::LeftArrow.is_extended(), true);
+    /// ```
+    /// 
+    /// [1]: https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag
+    /// [2]: https://stackoverflow.com/questions/71587520/how-to-use-sendinput-to-simulate-the-up-arrow-key-press-or-other-extended-keys
+    pub fn is_extended(self) -> bool {
+        match self {
+            // ALT and CTRL keys on the right-hand side of the keyboard
+            Vk::RightMenu | Vk::RightControl |
+            // ... the INS, DEL, HOME, END, PAGE UP, PAGE DOWN, and arrow keys
+            Vk::Insert | Vk::Delete |
+            Vk::Home | Vk::End |
+            Vk::PageUp | Vk::PageDown |
+            Vk::LeftArrow | Vk::RightArrow | Vk::UpArrow | Vk::DownArrow |
+            // ... NUM LOCK key; the BREAK (CTRL+PAUSE) key; the PRINT SCRN key;
+            Vk::Numlock | Vk::Pause | Vk::PrintScreen |
+            // ... the divide (/) and ENTER keys in the numeric keypad.
+            Vk::Divide
+            
+            => true,
+            _ => false,
+        }
+    }
 }


### PR DESCRIPTION
Two functions are added to `Vk`: `is_valid`, that determines wheter a given `u8` value is safe to convert to `Vk` enum, and `from_u8_safe` that converts an `u8` to an `Option<Vk>`.

For efficient implementation, a lazily-initialized static array is used (using [`lazy_static`](https://crates.io/crates/lazy_static)), with `bool`s corresponding to whether a given `u8` value (index in the array) is a valid Virtual Key. `strum` crate's [`EnumIter`](https://docs.rs/strum/latest/strum/derive.EnumIter.html) derive is used to allow iteration over an enum. 